### PR TITLE
Fix issue #63: Tạo API HelloFao

### DIFF
--- a/src/main/java/soft/blue/onboardingmerchant/controller/HelloFaoController.java
+++ b/src/main/java/soft/blue/onboardingmerchant/controller/HelloFaoController.java
@@ -1,0 +1,22 @@
+package soft.blue.onboardingmerchant.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api")
+@Tag(name = "Hello Fao", description = "Hello Fao API")
+public class HelloFaoController {
+
+    @GetMapping("/hello-fao")
+    @Operation(summary = "Get Hello Fao message", description = "Returns a JSON response with 'Hello Fao' message")
+    public ResponseEntity<Map<String, String>> getHelloFao() {
+        return ResponseEntity.ok(Map.of("data", "Hello Fao"));
+    }
+}

--- a/src/test/java/soft/blue/onboardingmerchant/controller/HelloFaoControllerTest.java
+++ b/src/test/java/soft/blue/onboardingmerchant/controller/HelloFaoControllerTest.java
@@ -1,0 +1,24 @@
+package soft.blue.onboardingmerchant.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(HelloFaoController.class)
+class HelloFaoControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldReturnHelloFaoMessage() throws Exception {
+        mockMvc.perform(get("/api/hello-fao"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value("Hello Fao"));
+    }
+}


### PR DESCRIPTION
This pull request fixes #63.

The issue appears to be successfully resolved based on the concrete changes implemented:

1. A new HelloFao controller was created that returns the exact required JSON response format {"data":"Hello Fao"}

2. Swagger/OpenAPI documentation was added to describe the API, which was a specific requirement in the original issue

3. The implementation includes test coverage to verify the endpoint's functionality

The changes directly address both core requirements from the issue description:
- Creating an API endpoint that returns the specified JSON format
- Adding Swagger documentation for the API

The AI agent's confirmation that both the API response and Swagger documentation are working correctly, combined with the presence of passing tests, provides sufficient evidence that the implementation meets the specified requirements. The changes are focused and targeted to exactly what was requested, without any extraneous modifications.

The implementation appears complete and functional based on the described changes, with no missing elements from the original requirements.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌